### PR TITLE
Change sort order of subcommittees

### DIFF
--- a/app/models/committee.rb
+++ b/app/models/committee.rb
@@ -16,7 +16,7 @@ class Committee < ActiveRecord::Base
   has_many :proposals
   has_many :discussions
 
-  scope :ordered, -> { order("preliminary, name") }
+  scope :ordered, -> { order("preliminary, id") }
 
   def to_s
     name


### PR DESCRIPTION
I would prefer to have the subcommittees sorted by the order I submit them (so their ID) rather than their name.

Best solution is to add an "order" field to the committee model, but I'll do that later if needed.
